### PR TITLE
Add icon for Linux X11

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -48,6 +48,7 @@ static void my_application_activate(GApplication* application) {
   }
 
   gtk_window_set_default_size(window, 1280, 720);
+  gtk_window_set_icon_from_file(window, "assets/icon/icon.png", NULL);
   gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();


### PR DESCRIPTION
Add icon for Linux X11.
When running on Wayland, the icon is still missing.